### PR TITLE
adding double as an allowed simple type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .buildpath
 .project
 .settings
+/composer.lock

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -288,14 +288,14 @@ class JsonMapper
     }
 
     /**
-     * Get additional properties setter method for the class. 
+     * Get additional properties setter method for the class.
      * @param  \ReflectionClass $rc Reflection class to check
      * @return \ReflectionMethod    Method or null if disabled.
      */
     protected function getAdditionalPropertiesMethod(\ReflectionClass $rc)
     {
-        if($this->bExceptionOnUndefinedProperty === false 
-            && $this->sAdditionalPropertiesCollectionMethod !== null) 
+        if($this->bExceptionOnUndefinedProperty === false
+            && $this->sAdditionalPropertiesCollectionMethod !== null)
         {
             $additionalPropertiesMethod = null;
             try {
@@ -427,7 +427,7 @@ class JsonMapper
                         $rprop = $p;
                         break;
                     }
-                }                
+                }
             }
         }
 
@@ -518,8 +518,8 @@ class JsonMapper
     {
         return $type == 'string'
             || $type == 'boolean' || $type == 'bool'
-            || $type == 'integer' || $type == 'int'
-            || $type == 'float' || $type == 'array' || $type == 'object';
+            || $type == 'integer' || $type == 'int'   || $type == 'float'
+            || $type == 'double'  || $type == 'array' || $type == 'object';
     }
 
     /**

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -18,6 +18,9 @@ require_once 'JsonMapperTest/Logger.php';
 require_once 'JsonMapperTest/PrivateWithSetter.php';
 require_once 'JsonMapperTest/ValueObject.php';
 
+use apimatic\jsonmapper\JsonMapper;
+use apimatic\jsonmapper\JsonMapperException;
+
 /**
  * Unit tests for JsonMapper
  *
@@ -55,6 +58,20 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertInternalType('float', $sn->fl);
         $this->assertEquals(1.2, $sn->fl);
+    }
+
+    /**
+     * Test for "@var double"
+     */
+    public function testMapSimpleDouble()
+    {
+        $jm = new JsonMapper();
+        $sn = $jm->map(
+            json_decode('{"db":"1.2"}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertInternalType('float', $sn->db);
+        $this->assertEquals(1.2, $sn->db);
     }
 
     /**
@@ -402,7 +419,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     /**
      * Test for "@var "
      *
-     * @expectedException JsonMapper_Exception
+     * @expectedException apimatic\jsonmapper\JsonMapperException
      * @expectedExceptionMessage Empty type at property "JsonMapperTest_Simple::$empty"
      */
     public function testMapEmpty()
@@ -573,7 +590,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        JsonMapper_Exception
+     * @expectedException        apimatic\jsonmapper\JsonMapperException
      * @expectedExceptionMessage Required property "pMissingData" of class JsonMapperTest_Broken is missing in JSON data
      */
     public function testMissingDataException()
@@ -601,7 +618,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        JsonMapper_Exception
+     * @expectedException        apimatic\jsonmapper\JsonMapperException
      * @expectedExceptionMessage JSON property "undefinedProperty" does not exist in object of type JsonMapperTest_Broken
      */
     public function testUndefinedPropertyException()
@@ -629,7 +646,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        JsonMapper_Exception
+     * @expectedException        apimatic\jsonmapper\JsonMapperException
      * @expectedExceptionMessage JSON property "privateNoSetter" has no public setter method in object of type PrivateWithSetter
      */
     public function testPrivatePropertyWithNoSetter()
@@ -647,7 +664,7 @@ class JsonMapperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        JsonMapper_Exception
+     * @expectedException        apimatic\jsonmapper\JsonMapperException
      * @expectedExceptionMessage JSON property "privatePropertyPrivateSetter" has no public setter method in object of type PrivateWithSetter
      */
     public function testPrivatePropertyWithPrivateSetter()

--- a/tests/JsonMapperTest/DependencyInjector.php
+++ b/tests/JsonMapperTest/DependencyInjector.php
@@ -1,5 +1,5 @@
 <?php
-class JsonMapperTest_DependencyInjector extends JsonMapper
+class JsonMapperTest_DependencyInjector extends \apimatic\jsonmapper\JsonMapper
 {
     /**
      * Create a new object of the given type.

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -53,6 +53,11 @@ class JsonMapperTest_Simple
     public $fl;
 
     /**
+     * @var double
+     */
+    public $db;
+
+    /**
      * @var mixed
      */
     public $mixed;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ if (is_dir(__DIR__ . '/../src/')) {
         . PATH_SEPARATOR . get_include_path()
     );
 }
+
 require_once 'JsonMapper.php';
-require_once 'JsonMapper/Exception.php';
+require_once 'JsonMapperException.php';
 ?>

--- a/tests/namespacetest/NamespaceTest.php
+++ b/tests/namespacetest/NamespaceTest.php
@@ -6,11 +6,13 @@ require_once __DIR__ . '/model/User.php';
 require_once __DIR__ . '/model/UserList.php';
 require_once __DIR__ . '/../othernamespace/Foo.php';
 
+use apimatic\jsonmapper\JsonMapper;
+
 class NamespaceTest extends \PHPUnit_Framework_TestCase
 {
     public function testMapArrayNamespace()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"data":[{"value":"1.2"}]}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
@@ -19,7 +21,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 
     public function testMapSimpleArrayNamespace()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"units":[{"value":"1.2"}]}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
@@ -28,7 +30,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 
     public function testMapSimpleStringArrayNamespace()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"messages":["message 1", "message 2"]}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
@@ -38,7 +40,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 
     public function testMapChildClassNamespace()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"user":{"name": "John Smith"}}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
@@ -47,7 +49,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 
     public function testMapChildClassConstructorNamespace()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"user":"John Smith"}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
@@ -56,7 +58,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 
     public function testMapChildObjectArrayNamespace()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"data":null,"user":{"name": "John Smith"}}';
         /* @var \namespacetest\UnitData $res */
         $res = $mapper->map(json_decode($json), new UnitData());
@@ -65,12 +67,12 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException JsonMapper_Exception
+     * @expectedException apimatic\jsonmapper\JsonMapperException
      * @expectedExceptionMessage Empty type at property "namespacetest\UnitData::$empty"
      */
     public function testMapEmpty()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"empty":{}}';
         /* @var \namespacetest\UnitData $res */
         $res = $mapper->map(json_decode($json), new UnitData());
@@ -78,7 +80,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 
     public function testMapCustomArraObjectWithChildType()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"users":[{"user":"John Smith"}]}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);
@@ -92,7 +94,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetterNamespacedTypeHint()
     {
-        $mapper = new \JsonMapper();
+        $mapper = new JsonMapper();
         $json = '{"namespacedTypeHint":"Foo"}';
         $res = $mapper->map(json_decode($json), new UnitData());
         $this->assertInstanceOf('\namespacetest\UnitData', $res);


### PR DESCRIPTION
The Apimatic code generation adds @var double for fields that are
defined as “Precision” in the UI, which would cause the mapper to throw
a class not found exception.  Adding double to the isSimpleType method.

Added a test for this as well, but that required some updates to
namespaces in the tests in order to get tests to run (seemed like they
weren’t updated after the namespaces were added).