### PR TITLE
fix: dont call deprecated method if using exactly version 8

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -691,7 +691,7 @@ class JsonMapper
      */
     protected function getParameterType(\ReflectionParameter $param)
     {
-        if (PHP_VERSION_ID <= 80000 && null !== $class = $param->getClass()) {
+        if (PHP_VERSION_ID < 80000 && null !== $class = $param->getClass()) {
             return "\\" . $class->getName();
         }
 


### PR DESCRIPTION
this should be a `<` instead of a `<=`