### PR TITLE
fix: applies isEnabled condition to parse_ini_file function call

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -125,8 +125,12 @@ class JsonMapper
 
         if (!isset($this->config)) {
             $iniPath = php_ini_loaded_file();
+            $functionEnabled = !in_array(
+                'parse_ini_file',
+                explode(PATH_SEPARATOR, ini_get('disable_functions'))
+            );
             $accessAllowed = $this->isPathAllowed($iniPath, ini_get('open_basedir'));
-            if ($accessAllowed && is_readable($iniPath)) {
+            if ($accessAllowed && $functionEnabled && is_readable($iniPath)) {
                 $this->config = parse_ini_file($iniPath);
             }
         }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -127,7 +127,7 @@ class JsonMapper
             $iniPath = php_ini_loaded_file();
             $functionEnabled = !in_array(
                 'parse_ini_file',
-                explode(PATH_SEPARATOR, ini_get('disable_functions'))
+                explode(',', ini_get('disable_functions'))
             );
             $accessAllowed = $this->isPathAllowed($iniPath, ini_get('open_basedir'));
             if ($accessAllowed && $functionEnabled && is_readable($iniPath)) {


### PR DESCRIPTION
## What
This PR adds a condition to calling `parse_ini_file()`, by checking if it doesn't exist in the disabled functions list

## Why
The disable_functions list in php.ini might contain parse_ini_file function call, as it parses the `.ini` file which tends to contain sensitive information apart from the required configuration.

Closes #47 

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
This PR does not introduce any breaking changes

## Testing
I have tested this change by adding `parse_ini_file` to the disable_functions option in php.ini file

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
