### PR TITLE
feat(additional-properties): adds support for typed additional properties

### DIFF
--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -323,10 +323,15 @@ class JsonMapper
     }
 
     /**
-     * @param ReflectionMethod|null $method
-     * @param object $object
-     * @param int|string $key
-     * @param mixed $value
+     * Add additional properties by invoking the specified method.
+     *
+     * @param ReflectionMethod|null $method Method to be called to add
+     *                                      additional properties to the class.
+     * @param object                $object Class instance on which the method
+     *                                      is invoked.
+     * @param int|string            $key    The name of additional property.
+     * @param mixed                 $value  The value of additional property.
+     *
      * @return void
      */
     protected function addAdditionalProperty($method, $object, $key, $value)
@@ -339,8 +344,9 @@ class JsonMapper
             $value = $this->getMappedValue(
                 $value,
                 $this->getDocTypeForArrayOrMixed(
-                    $this->getParameterType($method->getParameters()[0]),
-                    $annotations
+                    $this->getParameterType($method->getParameters()[1]),
+                    $annotations,
+                    1
                 ),
                 $this->getMapByAnnotationFromParsed($annotations),
                 $this->getFactoryMethods($annotations),
@@ -1654,24 +1660,31 @@ class JsonMapper
     }
 
     /**
-     * @param string|null $type
-     * @param array $annotations
+     * If the actual type is array or mixed, use the annotations to extract
+     * the type.
+     *
+     * @param string|null $type        The actual type of the parameter.
+     * @param array       $annotations The annotations to search the type.
+     * @param int         $index       The position of parameter in the function.
      *
      * @return string|null
      */
-    public function getDocTypeForArrayOrMixed($type, $annotations)
+    public function getDocTypeForArrayOrMixed($type, $annotations, $index = 0)
     {
         if (($type === null || $type === 'array' || $type === 'array|null')
-            && isset($annotations['param'][0])
+            && isset($annotations['param'][$index])
         ) {
-            list($type) = explode(' ', trim($annotations['param'][0]));
+            list($type) = explode(' ', trim($annotations['param'][$index]));
         }
 
         return $type;
     }
 
     /**
-     * @param array $annotations
+     * Get all factory methods from the list of annotations.
+     *
+     * @param array $annotations The annotations list.
+     *
      * @return string[]
      */
     public function getFactoryMethods(array $annotations)

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -1226,7 +1226,7 @@ class JsonMapperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals("yes", $fm->publicProp);
     }
 
-    public function testAdditionalPropertiesTyped()
+    public function testAdditionalPropertiesTypedNative()
     {
         $jm = new JsonMapper();
         $jm->sAdditionalPropertiesCollectionMethod = 'addTypedAdditionalProperty';
@@ -1236,6 +1236,23 @@ class JsonMapperTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertEquals(1, count($fm->additional));
         $this->assertEquals(123123, $fm->additional['random22']);
+    }
+
+    public function testAdditionalPropertiesTypedCustom()
+    {
+        $jm = new JsonMapper();
+        $jm->sAdditionalPropertiesCollectionMethod = 'addCustomTypedAdditionalProperty';
+        $fm = $jm->map(
+            json_decode('{"random11":"hello","random22":123123,"random33":{"under_score":"abc","random11":"hello","random33":{"fl":1.214}}}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertEquals(1, count($fm->additional));
+        $expected = new JsonMapperTest_Simple();
+        $expected->under_score = "abc";
+        $innerClass = new JsonMapperTest_Simple();
+        $innerClass->fl = 1.214;
+        $expected->addCustomTypedAdditionalProperty('random33', $innerClass);
+        $this->assertEquals($expected, $fm->additional['random33']);
     }
 
     public function testAdditionalPropertiesFactory()

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -1235,7 +1235,7 @@ class JsonMapperTest extends \PHPUnit\Framework\TestCase
             new JsonMapperTest_Simple()
         );
         $this->assertEquals(1, count($fm->additional));
-        $this->assertEquals("hello", $fm->additional['random11']);
+        $this->assertEquals(123123, $fm->additional['random22']);
     }
 
     public function testAdditionalPropertiesFactory()

--- a/tests/JsonMapperTest.php
+++ b/tests/JsonMapperTest.php
@@ -52,6 +52,8 @@ use apimatic\jsonmapper\JsonMapperException;
  * @covers \apimatic\jsonmapper\JsonMapper
  * @covers \apimatic\jsonmapper\TypeCombination
  * @covers \apimatic\jsonmapper\JsonMapperException
+ * @covers \apimatic\jsonmapper\OneOfValidationException
+ * @covers \apimatic\jsonmapper\AnyOfValidationException
  */
 class JsonMapperTest extends \PHPUnit\Framework\TestCase
 {
@@ -1222,6 +1224,60 @@ class JsonMapperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(123123, $fm->getAge());
         $this->assertEquals("value is factval", $fm->getMappedAndFactory());
         $this->assertEquals("yes", $fm->publicProp);
+    }
+
+    public function testAdditionalPropertiesTyped()
+    {
+        $jm = new JsonMapper();
+        $jm->sAdditionalPropertiesCollectionMethod = 'addTypedAdditionalProperty';
+        $fm = $jm->map(
+            json_decode('{"random11":"hello","random22":123123}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertEquals(1, count($fm->additional));
+        $this->assertEquals("hello", $fm->additional['random11']);
+    }
+
+    public function testAdditionalPropertiesFactory()
+    {
+        $jm = new JsonMapper();
+        $jm->sAdditionalPropertiesCollectionMethod = 'addFactoryAdditionalProperty';
+        $fm = $jm->map(
+            json_decode('{"random11":"hello","random22":123123,"random23":1,"random33":true}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertEquals(4, count($fm->additional));
+        $this->assertEquals(false, $fm->additional['random11']);
+        $this->assertEquals(false, $fm->additional['random22']);
+        $this->assertEquals(true, $fm->additional['random23']);
+        $this->assertEquals(false, $fm->additional['random33']);
+    }
+
+    public function testAdditionalPropertiesMapsBy()
+    {
+        $jm = new JsonMapper();
+        $jm->sAdditionalPropertiesCollectionMethod = 'addMapsByAdditionalProperty';
+        $fm = $jm->map(
+            json_decode('{"random11":"hello","random22":123.123,"random23":1.0,"random33":true}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertEquals(2, count($fm->additional));
+        $this->assertEquals('hello', $fm->additional['random11']);
+        $this->assertEquals(true, $fm->additional['random33']);
+    }
+
+    public function testAdditionalPropertiesMapsByFactory()
+    {
+        $jm = new JsonMapper();
+        $jm->sAdditionalPropertiesCollectionMethod = 'addMapsByFactoryAdditionalProperty';
+        $fm = $jm->map(
+            json_decode('{"random11":"hello","random22":123123,"random23":1,"random33":true}'),
+            new JsonMapperTest_Simple()
+        );
+        $this->assertEquals(3, count($fm->additional));
+        $this->assertEquals(false, $fm->additional['random22']);
+        $this->assertEquals(true, $fm->additional['random23']);
+        $this->assertEquals('value is 1', $fm->additional['random33']);
     }
 
     public function testAdditionalProperties()

--- a/tests/JsonMapperTest/FactoryMethod.php
+++ b/tests/JsonMapperTest/FactoryMethod.php
@@ -83,8 +83,24 @@ class FactoryMethod
         return 'value is ' . $value;
     }
 
+    public static function createFromBoolStrict($value)
+    {
+        if (!is_bool($value)) {
+            throw new InvalidArgumentException('Only boolean types are allowed');
+        }
+        return 'value is ' . $value;
+    }
+
     public static function createFromInt($value)
     {
+        return $value === 1;
+    }
+
+    public static function createFromIntStrict($value)
+    {
+        if (!is_numeric($value)) {
+            throw new InvalidArgumentException('Only integer types are allowed');
+        }
         return $value === 1;
     }
 

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -168,7 +168,7 @@ class JsonMapperTest_Simple
 
     /**
      * @param string $key
-     * @param string $value
+     * @param int $value
      */
     public function addTypedAdditionalProperty($key, $value)
     {

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -166,6 +166,50 @@ class JsonMapperTest_Simple
         $this->additional[$key] = $value;
     }
 
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function addTypedAdditionalProperty($key, $value)
+    {
+        $this->additional[$key] = $value;
+    }
+
+    /**
+     * @factory FactoryMethod::createFromInt
+     *
+     * @param string $key
+     * @param bool $value
+     */
+    public function addFactoryAdditionalProperty($key, $value)
+    {
+        $this->additional[$key] = $value;
+    }
+
+    /**
+     * @mapsBy oneOf(float,mixed)
+     *
+     * @param string $key
+     * @param int|float $value
+     */
+    public function addMapsByAdditionalProperty($key, $value)
+    {
+        $this->additional[$key] = $value;
+    }
+
+    /**
+     * @mapsBy anyOf(int,bool)
+     * @factory FactoryMethod::createFromIntStrict int
+     * @factory FactoryMethod::createFromBoolStrict bool
+     *
+     * @param string $key
+     * @param int|bool $value
+     */
+    public function addMapsByFactoryAdditionalProperty($key, $value)
+    {
+        $this->additional[$key] = $value;
+    }
+
     private function privateAddAdditionalProperty($key, $value)
     {
         $this->additional[$key] = $value;

--- a/tests/JsonMapperTest/Simple.php
+++ b/tests/JsonMapperTest/Simple.php
@@ -176,6 +176,15 @@ class JsonMapperTest_Simple
     }
 
     /**
+     * @param string $key
+     * @param JsonMapperTest_Simple $value
+     */
+    public function addCustomTypedAdditionalProperty($key, $value)
+    {
+        $this->additional[$key] = $value;
+    }
+
+    /**
      * @factory FactoryMethod::createFromInt
      *
      * @param string $key


### PR DESCRIPTION
## What
This PR adds the capability to set up additional properties of a particular type, while the jsonmapper ignore invalid types silently

## Why
To support typed/strict additional properties

Closes #53 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [X] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [X] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
I have added unit tests to my code

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
